### PR TITLE
use vim.lsp.util.show_document

### DIFF
--- a/lua/lsplinks.lua
+++ b/lua/lsplinks.lua
@@ -131,7 +131,7 @@ function M.open(uri)
     return false
   end
   if uri:find("^file:/") then
-    util.jump_to_location({ uri = remove_uri_fragment(uri) }, "utf-8", true)
+    util.show_document({ uri = remove_uri_fragment(uri) }, "utf-8", { reuse_win = true, focus = true })
     local line_no, col_no = uri:match(".-#(%d+),(%d+)")
     if line_no then
       api.nvim_win_set_cursor(0, { tonumber(line_no), tonumber(col_no) - 1 })


### PR DESCRIPTION
Since `vim.lsp.util.jump_to_location` is [deprecated in `v0.11.0`], this PR uses [`vim.lsp.util.show_document`] instead. The change should be backward compatible as [`jump_to_location` in `v0.9.0`] is just implemented by forwarding arguments to `show_document`.

[`jump_to_location` in `v0.9.0`]: https://github.com/neovim/neovim/blob/v0.9.0/runtime/lua/vim/lsp/util.lua#L1167-L1182
[deprecated in `v0.11.0`]: https://neovim.io/doc/user/deprecated.html#vim.lsp.util.jump_to_location
[`vim.lsp.util.show_document`]: https://neovim.io/doc/user/lsp.html#vim.lsp.util.show_document()